### PR TITLE
health(criteria): #78 made remaining criterion reduction specs more c…

### DIFF
--- a/src/criteria/test/reduction/and-combined-value-criteria.spec.ts
+++ b/src/criteria/test/reduction/and-combined-value-criteria.spec.ts
@@ -1,78 +1,26 @@
-import { and, inRange, inSet, isEven, or } from "../../value-criterion";
+import { reducing } from "./reducing.fn";
 
 describe("reducing: and-combined-value-criteria", () => {
     describe("full reduction", () => {
-        it("([2, 3] & is-even) should be fully reduced by [1, 7]", () => {
-            // arrange
-            const a = and([inRange(2, 3), isEven(true)]);
-            const b = inRange(1, 7);
-
-            // act
-            const reduced = b.reduce(a);
-
-            // assert
-            expect(reduced).toBe(true);
-        });
+        reducing("([2, 3] & is-even)").by("[1, 7]").is(true);
     });
 
     describe("partial reduction", () => {
-        it("([3, 10] & is-even) reduced by [1, 7] should be ((7, 10] & {10})", () => {
-            // arrange
-            const a = and([inRange(3, 10), isEven(true)]);
-            const b = inRange(1, 7);
-            const expected = and([inRange(7, 10, [false, true]), isEven(true)]);
-
-            // act
-            const reduced = b.reduce(a);
-
-            // assert
-            expect(reduced).toEqual(expected);
-        });
-
-        it("[1, 7] reduced by ([3, 5] & is-even) should be (([1, 3) | (5, 7]) | ([3, 5] & is-odd))", () => {
-            // arrange
-            const a = inRange(1, 7);
-            const b = and([inRange(3, 5), isEven(true)]);
-            const expected = or([or([inRange(1, 3, [true, false]), inRange(5, 7, [false, true])]), and([inRange(3, 5), isEven(false)])]);
-
-            const reduced = b.reduce(a);
-
-            // assert
-            expect(reduced).toEqual(expected);
-        });
-
-        it("[1, 7] reduced by (is-even & [3, 5]) should be (([1, 3) | (5, 7]) | ([3, 5] & is-odd))", () => {
-            // arrange
-            const a = inRange(1, 7);
-            const b = and([isEven(true), inRange(3, 5)]);
-            const expected = or([or([inRange(1, 3, [true, false]), inRange(5, 7, [false, true])]), and([inRange(3, 5), isEven(false)])]);
-
-            const reduced = b.reduce(a);
-
-            // assert
-            expect(reduced).toEqual(expected);
-        });
+        reducing("([3, 10] & is-even)").by("[1, 7]").is("((7, 10] & is-even)");
+        reducing("[1, 7]").by("([3, 5] & is-even)").is("(([1, 3) | (5, 7]) | ([3, 5] & is-odd))");
+        reducing("[1, 7]").by("(is-even & [3, 5])").is("(([1, 3) | (5, 7]) | ([3, 5] & is-odd))");
 
         xit("[4, 8] reduced by ([1, 7] & [5, 12]) should be ((7, 8] | [4, 5))", () => {
-            //
+            // [todo] doesn't work yet, revisit
+            //reducing("[4, 8]").by("([1, 7] & [5, 12])").is("((7, 8] | [4, 5))");
         });
 
         xit("starts-with(foo) reduced by (starts-with(foo) & contains(bar) & ends-with(baz)) should be (starts-with(foo) & !(contains(bar) & ends-with(baz))) ", () => {
-            //
+            // [todo] string fn criteria not yet implemented
         });
     });
 
     describe("no reduction", () => {
-        it("({5} & [8, 10]) should not be reduced by [1, 7]", () => {
-            // arrange
-            const a = and([inSet([5]), inRange(8, 10)]);
-            const b = inRange(1, 7);
-
-            // act
-            const reduced = b.reduce(a);
-
-            // assert
-            expect(reduced).toBe(false);
-        });
+        reducing("({5} & [8, 10])").by("[1, 7]").is(false);
     });
 });

--- a/src/criteria/test/reduction/binary.spec.ts
+++ b/src/criteria/test/reduction/binary.spec.ts
@@ -1,17 +1,7 @@
-import { isEven } from "../../value-criterion";
+import { reducing } from "./reducing.fn";
 
 describe("reducing: binary", () => {
     describe("full reduction", () => {
-        it("is-even should be fully reduced by itself", () => {
-            // arrange
-            const a = isEven(true);
-            const b = isEven(true);
-
-            // act
-            const reduced = b.reduce(a);
-
-            // assert
-            expect(reduced).toBe(true);
-        });
+        reducing("is-even").by("is-even").is(true);
     });
 });


### PR DESCRIPTION
- maybe put some specs next to source files
  ✔ put criteria specs into src/criteria/test folder
- try to find nice & concise helper code for the reduction specs - so many cases have exact same structure & waste so many lines, makes files too big
  ✔ implemented by using the string representation of criteria (which are then parsed into instances)
- we could also try group multiple cases into an "it()" (instead of 1 reduction case per "it()")
  ❌ each case is it's own - if we were to group them, one failure prevents other cases in the same group not to be run
- there is quite some dirty code lingering all across the src files
  ✔ i've cleaned up some stuff here and there. still a lot of polish possible, but good enough to be merged already